### PR TITLE
Configure CORS headers in Django backend

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -9,6 +9,8 @@ DEBUG = os.getenv('DEBUG', '1') == '1'
 
 ALLOWED_HOSTS = []
 
+CORS_ALLOWED_ORIGINS = [os.getenv('REACT_APP_API_URL')] if os.getenv('REACT_APP_API_URL') else []
+
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
@@ -16,11 +18,13 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders',
     'products',
 ]
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,1 +1,2 @@
 Django>=4.2,<5.0
+django-cors-headers>=4.0,<5.0


### PR DESCRIPTION
## Summary
- add `django-cors-headers` dependency
- enable `corsheaders` in apps and middleware
- set `CORS_ALLOWED_ORIGINS` from `REACT_APP_API_URL`

## Testing
- `pip install -r backend/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'corsheaders')*

------
https://chatgpt.com/codex/tasks/task_e_68c4d3db6a8483319ab34e72d909abce