### PR TITLE
Add DRF product API

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -16,6 +16,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
     'products',
 ]
 
@@ -71,3 +72,9 @@ USE_TZ = True
 STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.AllowAny',
+    ]
+}

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -1,6 +1,10 @@
 from django.contrib import admin
 from django.urls import path
 
+from products.views import ProductDetail, ProductList
+
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('products/', ProductList.as_view(), name='product-list'),
+    path('products/<int:pk>/', ProductDetail.as_view(), name='product-detail'),
 ]

--- a/backend/products/serializers.py
+++ b/backend/products/serializers.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+
+from .models import Product
+
+
+class ProductSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Product
+        fields = ['id', 'name', 'description', 'price', 'stock']
+

--- a/backend/products/tests.py
+++ b/backend/products/tests.py
@@ -1,3 +1,29 @@
-from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
 
-# Create your tests here.
+from .models import Product
+
+
+class ProductAPITestCase(APITestCase):
+    def setUp(self):
+        self.product = Product.objects.create(
+            name='Test Product',
+            description='A product for testing',
+            price=9.99,
+            stock=10,
+        )
+
+    def test_list_products(self):
+        url = reverse('product-list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], 'Test Product')
+
+    def test_retrieve_product(self):
+        url = reverse('product-detail', args=[self.product.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['name'], 'Test Product')
+

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -1,3 +1,15 @@
-from django.shortcuts import render
+from rest_framework import generics
 
-# Create your views here.
+from .models import Product
+from .serializers import ProductSerializer
+
+
+class ProductList(generics.ListAPIView):
+    queryset = Product.objects.all()
+    serializer_class = ProductSerializer
+
+
+class ProductDetail(generics.RetrieveAPIView):
+    queryset = Product.objects.all()
+    serializer_class = ProductSerializer
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,1 +1,2 @@
 Django>=4.2,<5.0
+djangorestframework>=3.14,<4.0


### PR DESCRIPTION
## Summary
- add Django REST Framework to project configuration
- expose list and detail product endpoints with serializers and tests

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement djangorestframework<4.0,>=3.14)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_68c4d3d036108331af3ee41d22c9d7a7