### PR TITLE
Ensure INSTALLED_APPS includes rest_framework once

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -19,6 +19,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'corsheaders',
+    'rest_framework',
     'products',
 ]
 


### PR DESCRIPTION
## Summary
- add missing `rest_framework` entry to `INSTALLED_APPS`
- ensure `products` only appears once and merge markers removed

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'corsheaders')*


------
https://chatgpt.com/codex/tasks/task_e_68c4d551b60c833194964ec9890ce9cb