### PR TITLE
Add product pages and routing to frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "react-router-dom": "^6.22.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/components/ProductDetail.js
+++ b/frontend/src/components/ProductDetail.js
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+
+const ProductDetail = () => {
+  const { id } = useParams();
+  const [product, setProduct] = useState(null);
+
+  useEffect(() => {
+    const fetchProduct = async () => {
+      try {
+        const res = await fetch(`${process.env.REACT_APP_API_URL}/products/${id}/`);
+        const data = await res.json();
+        setProduct(data);
+      } catch (err) {
+        console.error('Failed to fetch product', err);
+      }
+    };
+    fetchProduct();
+  }, [id]);
+
+  if (!product) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h1>{product.name}</h1>
+      {product.description && <p>{product.description}</p>}
+      {product.price && <p>Price: ${product.price}</p>}
+      <Link to="/">Back to products</Link>
+    </div>
+  );
+};
+
+export default ProductDetail;

--- a/frontend/src/components/ProductList.js
+++ b/frontend/src/components/ProductList.js
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+const ProductList = () => {
+  const [products, setProducts] = useState([]);
+
+  useEffect(() => {
+    const fetchProducts = async () => {
+      try {
+        const res = await fetch(`${process.env.REACT_APP_API_URL}/products/`);
+        const data = await res.json();
+        setProducts(data);
+      } catch (err) {
+        console.error('Failed to fetch products', err);
+      }
+    };
+    fetchProducts();
+  }, []);
+
+  return (
+    <div>
+      <h1>Products</h1>
+      <ul>
+        {products.map(product => (
+          <li key={product.id}>
+            <Link to={`/product/${product.id}`}>{product.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ProductList;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,13 +1,20 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './index.css';
-import App from './App';
+import ProductList from './components/ProductList';
+import ProductDetail from './components/ProductDetail';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<ProductList />} />
+        <Route path="/product/:id" element={<ProductDetail />} />
+      </Routes>
+    </BrowserRouter>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- add `react-router-dom` dependency
- create `ProductList` and `ProductDetail` components fetching products from API
- configure browser routes for list and detail pages

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d7566afc83318ac023b8d3ebaa8d