### PR TITLE
Add backend and frontend tests setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ Aplicación de ejemplo para comercio electrónico con backend en Django y fronte
 ### Comandos útiles
 - `npm test`
 
+## Pruebas
+
+### Backend
+1. `cd backend`
+2. `python manage.py test`
+
+### Frontend
+1. `cd frontend`
+2. `npm test`
+

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/products/', include('products.urls')),
 ]

--- a/backend/products/serializers.py
+++ b/backend/products/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from .models import Product
+
+
+class ProductSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Product
+        fields = '__all__'

--- a/backend/products/tests.py
+++ b/backend/products/tests.py
@@ -1,3 +1,44 @@
+from decimal import Decimal
 from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
 
-# Create your tests here.
+from .models import Product
+
+
+class ProductModelTest(TestCase):
+    def test_str_returns_name(self):
+        product = Product.objects.create(
+            name='Test Product',
+            description='A product used for testing',
+            price=Decimal('9.99'),
+            stock=5,
+        )
+        self.assertEqual(str(product), 'Test Product')
+
+
+class ProductAPITest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.product = Product.objects.create(
+            name='API Product',
+            description='Product via API',
+            price=Decimal('19.99'),
+            stock=10,
+        )
+
+    def test_list_products(self):
+        url = reverse('product-list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['name'], self.product.name)
+
+    def test_retrieve_product(self):
+        url = reverse('product-detail', args=[self.product.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data['name'], self.product.name)

--- a/backend/products/urls.py
+++ b/backend/products/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from .views import ProductList, ProductDetail
+
+urlpatterns = [
+    path('', ProductList.as_view(), name='product-list'),
+    path('<int:pk>/', ProductDetail.as_view(), name='product-detail'),
+]

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -1,3 +1,13 @@
-from django.shortcuts import render
+from rest_framework import generics
+from .models import Product
+from .serializers import ProductSerializer
 
-# Create your views here.
+
+class ProductList(generics.ListCreateAPIView):
+    queryset = Product.objects.all()
+    serializer_class = ProductSerializer
+
+
+class ProductDetail(generics.RetrieveAPIView):
+    queryset = Product.objects.all()
+    serializer_class = ProductSerializer

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,10 @@
     "react-router-dom": "^6.22.3",
     "bootstrap": "^5.3.3"
   },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^13.4.0"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/frontend/src/components/ProductDetail.test.js
+++ b/frontend/src/components/ProductDetail.test.js
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+describe('ProductDetail', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ id: 1, name: 'Product 1', description: 'Desc' }),
+      })
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders product details from API', async () => {
+    const ProductDetail = require('./ProductDetail').default;
+    render(
+      <MemoryRouter initialEntries={["/product/1"]}>
+        <Routes>
+          <Route path="/product/:id" element={<ProductDetail />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(await screen.findByText('Product 1')).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/ProductList.test.js
+++ b/frontend/src/components/ProductList.test.js
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+
+describe('ProductList', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve([{ id: 1, name: 'Test Product' }]),
+      })
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders products fetched from API', async () => {
+    const ProductList = require('./ProductList').default;
+    render(<ProductList />);
+    expect(await screen.findByText('Test Product')).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add DRF endpoints for products and unit tests
- configure React Testing Library and example component tests
- document how to run backend and frontend tests

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'corsheaders')*
- `CI=true npm test` *(fails: Cannot find module '@testing-library/jest-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68c4d913c36c83319d45d5454750892f