### PR TITLE
Configure CORS headers for React frontend

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -9,7 +9,10 @@ DEBUG = os.getenv('DEBUG', '1') == '1'
 
 ALLOWED_HOSTS = []
 
-CORS_ALLOWED_ORIGINS = [os.getenv('REACT_APP_API_URL')] if os.getenv('REACT_APP_API_URL') else []
+# Allow the React development server to access the API.
+CORS_ALLOWED_ORIGINS = [
+    'http://localhost:3000',
+]
 
 INSTALLED_APPS = [
     'django.contrib.admin',
@@ -24,8 +27,8 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
     'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
## Summary
- Allow React dev server access via `CORS_ALLOWED_ORIGINS` and move `CorsMiddleware` to the top of `MIDDLEWARE`.

## Testing
- `pip install django-cors-headers`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'rest_framework')*


------
https://chatgpt.com/codex/tasks/task_e_68c4dd5e5a9c8331a8c98c8e0fc48e59