### PR TITLE
Add Product model fields and CRUD endpoints

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -3,5 +3,5 @@ from django.urls import include, path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/products/', include('products.urls')),
+    path('api/products/', include('routes.products')),
 ]

--- a/backend/products/migrations/0002_product_category_image_url.py
+++ b/backend/products/migrations/0002_product_category_image_url.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('products', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='product',
+            name='category',
+            field=models.CharField(blank=True, max_length=100),
+        ),
+        migrations.AddField(
+            model_name='product',
+            name='image_url',
+            field=models.URLField(blank=True, null=True),
+        ),
+    ]
+

--- a/backend/products/models.py
+++ b/backend/products/models.py
@@ -2,10 +2,13 @@ from django.db import models
 
 
 class Product(models.Model):
+    id = models.BigAutoField(primary_key=True)
     name = models.CharField(max_length=255)
     description = models.TextField()
     price = models.DecimalField(max_digits=10, decimal_places=2)
     stock = models.IntegerField()
+    category = models.CharField(max_length=100, blank=True)
+    image_url = models.URLField(blank=True, null=True)
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.name

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -8,6 +8,6 @@ class ProductList(generics.ListCreateAPIView):
     serializer_class = ProductSerializer
 
 
-class ProductDetail(generics.RetrieveAPIView):
+class ProductDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Product.objects.all()
     serializer_class = ProductSerializer

--- a/backend/routes/products.py
+++ b/backend/routes/products.py
@@ -1,7 +1,10 @@
 from django.urls import path
-from .views import ProductList, ProductDetail
+
+from products.views import ProductList, ProductDetail
+
 
 urlpatterns = [
     path('', ProductList.as_view(), name='product-list'),
     path('<int:pk>/', ProductDetail.as_view(), name='product-detail'),
 ]
+


### PR DESCRIPTION
## Summary
- expand Product model to include id, category, and image_url
- expose CRUD endpoints for products under dedicated routes module
- add migration for new Product fields

## Testing
- `python backend/manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'rest_framework')*
- `python backend/manage.py migrate` *(fails: ModuleNotFoundError: No module named 'rest_framework')*
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_68c4de4f2fb883318701aae9279e36da